### PR TITLE
Pre-build path tests fail if cwd has spaces

### DIFF
--- a/test/test-optipng-path.js
+++ b/test/test-optipng-path.js
@@ -4,7 +4,7 @@
 var assert = require('assert');
 var path = require('path');
 var fs = require('fs');
-var exec = require('child_process').exec;
+var execFile = require('child_process').execFile;
 
 describe('OptiPNG', function () {
 	after(function () {
@@ -14,7 +14,7 @@ describe('OptiPNG', function () {
 	it('should return path to OptiPNG binary', function (cb) {
 		var binPath = require('../lib/optipng-bin.js').path;
 
-		exec(binPath + ' -v -', function (err, stdout, stderr) {
+		execFile(binPath, ['-v', '-'], function (err, stdout, stderr) {
 			assert(stderr.toString().indexOf('OptiPNG') !== -1);
 			cb();
 		});
@@ -23,7 +23,7 @@ describe('OptiPNG', function () {
 	it('should successfully proxy OptiPNG', function (cb) {
 		var binPath = path.join(__dirname, '../bin/optipng-bin');
 
-		exec('node ' + binPath + ' -v -', function (err, stdout, stderr) {
+		execFile('node', [binPath, '-v', '-'], function (err, stdout, stderr) {
 			assert(stderr.toString().indexOf('OptiPNG') !== -1);
 			cb();
 		});
@@ -39,7 +39,7 @@ describe('OptiPNG', function () {
 			path.join(__dirname, 'fixtures', 'test.png')
 		];
 
-		exec('node ' + binPath + ' ' + args.join(' '), function () {
+		execFile('node', [binPath].concat(args), function () {
 			var actual = fs.statSync('test/minified.png').size;
 			var original = fs.statSync('test/fixtures/test.png').size;
 			assert(actual < original);


### PR DESCRIPTION
_test/test-optipng-path.js_ fails if paths have spaces in them (that's dirty, I know...). Added quotes around the pathnames to prevent this. There's still the issue of optipng compile from sources not working for paths with spaces, though, but at least if tests succeed the module is usable.
