### PR TITLE
Added which utility to find pre-installed version of optipng

### DIFF
--- a/lib/optipng-bin.js
+++ b/lib/optipng-bin.js
@@ -9,15 +9,15 @@ function setPath(){
     return optipath;
   }
   catch(e) {
-console.log(e);
+    console.log(e);
     if (process.platform === 'darwin') {
       return path.join(__dirname, '../vendor/osx', 'optipng');
     } else if (process.platform === 'linux') {
-        if (process.arch === 'x64') {
-          return path.join(__dirname, '../vendor/linux/x64', 'optipng');
-	} else {
-          return path.join(__dirname, '../vendor/linux/x86', 'optipng');
-	}
+      if (process.arch === 'x64') {
+        return path.join(__dirname, '../vendor/linux/x64', 'optipng');
+	    } else {
+        return path.join(__dirname, '../vendor/linux/x86', 'optipng');
+      }
     } else if (process.platform === 'win32') {
       return path.join(__dirname, '../vendor/win32', 'optipng.exe');
     } else {


### PR DESCRIPTION
When trying to use yeoman on webfaction shared servers (CentOS) where I do not have permissions for global installs and src builds, I needed a method to point to the pre installed binary. With this change, I can run:

`$ npm install`

and it will use the optipng binary located at:

`$HOME/bin/optipng`
