### PR TITLE
set prefix to /tmp/optipng/out when building

### DIFF
--- a/lib/optipng.js
+++ b/lib/optipng.js
@@ -8,7 +8,7 @@ var options = {
 	bin: 'optipng',
 	path: path.join(__dirname, '../vendor'),
 	src: 'http://downloads.sourceforge.net/project/optipng/OptiPNG/optipng-0.7.4/optipng-0.7.4.tar.gz',
-	buildScript: './configure --with-system-zlib --bindir="' + path.join(__dirname, '../vendor') + '" && ' +
+	buildScript: './configure --with-system-zlib --prefix="`pwd`/out" --bindir="' + path.join(__dirname, '../vendor') + '" && ' +
 				 'make install',
 	platform: {
 		darwin: {

--- a/test/test-build.js
+++ b/test/test-build.js
@@ -13,7 +13,7 @@ describe('optipng.build()', function () {
 		var bin = new Bin(options);
 
 		bin.path = path.join(__dirname, '../tmp', bin.bin);
-		bin.buildScript = './configure --with-system-zlib --bindir="' + path.join(__dirname, '../tmp') + '" && ' +
+		bin.buildScript = './configure --with-system-zlib --prefix="`pwd`/out" --bindir="' + path.join(__dirname, '../tmp') + '" && ' +
 				 		  'make install';
 
 		bin.build(function () {


### PR DESCRIPTION
Without this patch, installation fails on Linux systems that cannot use the precompiled binaries and do not have /usr/local/share/man/man1/optipng.1 writable by the user, such as Debian armhf. This node module should not install man pages anyway.

It looks like there is an underescaping bug on these lines that could cause problems if any parent directories contain special characters. I'm not sure how big of a deal that really is and I don't know how to fix it properly cross-platform without modifying bin-wrapper to use a build function instead of a shell command.
