### PR TITLE
bin-wrapper 0.3.x introduces breaking change in API.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "image"
   ],
   "dependencies": {
-    "bin-wrapper": "^0.2.0",
+    "bin-wrapper": "0.2.x",
     "chalk": "^0.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
See https://github.com/kevva/imagemin/issues/30

Fixes #32
