### PR TITLE
fix - if optipng is in $PATH

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ var chalk = require('chalk');
 var fs = require('fs');
 var path = require('path');
 
+var globalBin = false;
+
 /**
  * Initialize a new BinWrapper
  */
@@ -43,9 +45,12 @@ fs.exists(bin.use(), function (exists) {
 
 					console.log(chalk.green('✓ optipng built successfully'));
 				});
+			} else {
+				globalBin = true;
+				console.log(chalk.green('✓ pre-build test passed successfully'));
 			}
 
-			console.log(chalk.green('✓ pre-build test passed successfully'));
+
 		});
 	}
 });
@@ -54,4 +59,8 @@ fs.exists(bin.use(), function (exists) {
  * Module exports
  */
 
-module.exports.path = bin.use();
+module.exports.path = function(){
+	if (!globalBin)
+		bin.use();
+	return (process.platform === 'win32' ? 'optipng.exe' : 'optipng');
+}();


### PR DESCRIPTION
I encountered an ENOENT error while using this module with your gulp-imagemin. The reason was that i already had optipng installed somewhere in my $PATH. In this case optipng isn't installed (correct) but bin.use() returns something like node_modules/xyz/vendors/optipng. The problematic part is that also the folder vendors doesnt exist in this case. Calling optipng in a no existent folder raises an ENOENT error thus fails.
