### PR TITLE
Switch to latest version of upstream optipng source code

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -11,7 +11,7 @@ bin.run(function (err) {
 		log.info('compiling from source');
 
 		new BinBuild()
-			.src('http://downloads.sourceforge.net/project/optipng/OptiPNG/optipng-0.7.5/optipng-0.7.5.tar.gz')
+			.src('http://downloads.sourceforge.net/project/optipng/OptiPNG/optipng-0.7.6/optipng-0.7.6.tar.gz')
 			.cmd([
 				'./configure --with-system-zlib --prefix="' + bin.dest() + '"',
 				'--bindir="' + bin.dest() + '"'

--- a/test/test.js
+++ b/test/test.js
@@ -22,7 +22,7 @@ afterEach(function () {
 
 it('rebuild the optipng binaries', function (cb) {
 	new BinBuild()
-		.src('http://downloads.sourceforge.net/project/optipng/OptiPNG/optipng-0.7.5/optipng-0.7.5.tar.gz')
+		.src('http://downloads.sourceforge.net/project/optipng/OptiPNG/optipng-0.7.6/optipng-0.7.6.tar.gz')
 		.cmd('./configure --with-system-zlib --prefix="' + tmp + '" --bindir="' + tmp + '"')
 		.cmd('make install')
 		.run(function (err) {


### PR DESCRIPTION
When precompiled binary fetched from raw.github.com failed to work, the installation script would try to fetch source code from sourceforge upstream and compile it locally. However the source code failed to compile on my Linux x86-64 machine due to syntax errors in their source code (optipng-0.7.5). The problematic code looks like this:

```
...
#define OPNG_LONGEST_IMPL_FORMAT OPNG_LLONG_FORMAT
#else
typedef long opng_longest_impl_t;
typedef unsigned long opng_longest_impl_t;
#define OPNG_LONGEST_IMPL_FORMAT "l"
...
```

Type `opng_longest_impl_t` was defined twice due to a simple typo so it failed to compile on some circumstances (depending on the precompile conditional directives), while the latest source (version 0.7.6 released on 2016-04-04) has already fixed this problem. Moreover, the old version also has problems compiling on OS X 10.11.3, while the new version compiled smoothly.

I tried the latest upstream version of optipng against this npm package and it worked great in the first glance, so I wonder if switching to latest upstream source would be a good option and thus open this pull request.