### PR TITLE
Allow to retrieve the executable url from somewhere in

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
 var path = require('path');
 var BinWrapper = require('bin-wrapper');
 var pkg = require('../package.json');
-var url = 'https://raw.github.com/imagemin/optipng-bin/v' + pkg.version + '/vendor/';
+var url = process.env.npm_config_optipng_bin || 'https://raw.github.com/imagemin/optipng-bin/v' + pkg.version + '/vendor/';
 
 module.exports = new BinWrapper()
 	.src(url + 'osx/optipng', 'darwin')

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@ image files to a smaller size, without losing any information.
 $ npm install --save optipng-bin
 ```
 
+If needed, you can specify the `optipng_bin` variable to change the default optipng executable download path.
 
 ## Usage
 


### PR DESCRIPTION
This should fix #71.

The same patch should also be applied to every other bin project in node
