### PR TITLE
Fix building on Apple Silicon

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -13,10 +13,15 @@ import bin from './index.js';
 		console.info('compiling from source');
 
 		try {
+			let buildFlags = ''
+			if (process.arch === 'arm64') {
+				buildFlags = 'CPPFLAGS="-DPNG_ARM_NEON_OPT=0" '
+			}
+
 			const source = fileURLToPath(new URL('../vendor/source/optipng.tar.gz', import.meta.url));
 			// From https://sourceforge.net/projects/optipng/files/OptiPNG/
 			await binBuild.file(source, [
-				`./configure --with-system-zlib --prefix="${bin.dest()}" --bindir="${bin.dest()}"`,
+				`${buildFlags}./configure --with-system-zlib --prefix="${bin.dest()}" --bindir="${bin.dest()}"`,
 				'make install',
 			]);
 


### PR DESCRIPTION
Currently on Apple Silicon without Rosetta, this package fails to build because `optipng` uses neon instructions that don't work on arm64. This PR applies the fix from #118 to `install.js` so we can build and use optipng-bin on Apple Silicon without Rosetta.

I believe this will fix #118 and #123.

Without this patch we get the following when we try an `npm install`:

```
node_modules/.pnpm/optipng-bin@7.0.1/node_modules/optipng-bin: Running postinstall script, failed in 5.3s
.../node_modules/optipng-bin postinstall$ node lib/install.js
│ spawn Unknown system error -86
│ optipng pre-build test failed
│ compiling from source
│ Error: Command failed: /bin/sh -c make install
│ pngrtran.c:99:1: warning: unused function 'png_rtran_ok' [-Wunused-function]
│ png_rtran_ok(png_structrp png_ptr, int need_IHDR)
│ ^
│ 1 warning generated.
│ pngrutil.c:3536:20: warning: performing pointer subtraction with a null pointer has undefined behavior [-Wnull-pointer-subtraction]
│                    png_isaligned(dp, png_uint_16) &&
│                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
│ ./pngpriv.h:597:29: note: expanded from macro 'png_isaligned'
│    (((type)((const char*)ptr-(const char*)0) & \
│                             ^~~~~~~~~~~~~~~
│ pngrutil.c:3537:20: warning: performing pointer subtraction with a null pointer has undefined behavior [-Wnull-pointer-subtraction]
│                    png_isaligned(sp, png_uint_16) &&
│                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
│ ./pngpriv.h:597:29: note: expanded from macro 'png_isaligned'
│    (((type)((const char*)ptr-(const char*)0) & \
│                             ^~~~~~~~~~~~~~~
│ pngrutil.c:3544:23: warning: performing pointer subtraction with a null pointer has undefined behavior [-Wnull-pointer-subtraction]
│                   if (png_isaligned(dp, png_uint_32) &&
│                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
│ ./pngpriv.h:597:29: note: expanded from macro 'png_isaligned'
│    (((type)((const char*)ptr-(const char*)0) & \
│                             ^~~~~~~~~~~~~~~
│ pngrutil.c:3545:23: warning: performing pointer subtraction with a null pointer has undefined behavior [-Wnull-pointer-subtraction]
│                       png_isaligned(sp, png_uint_32) &&
│                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
│ ./pngpriv.h:597:29: note: expanded from macro 'png_isaligned'
│    (((type)((const char*)ptr-(const char*)0) & \
│                             ^~~~~~~~~~~~~~~
│ pngrutil.c:4604:34: warning: performing pointer subtraction with a null pointer has undefined behavior [-Wnull-pointer-subtraction]
│          int extra = (int)((temp - (png_bytep)0) & 0x0f);
│                                  ^ ~~~~~~~~~~~~
│ pngrutil.c:4608:30: warning: performing pointer subtraction with a null pointer has undefined behavior [-Wnull-pointer-subtraction]
│          extra = (int)((temp - (png_bytep)0) & 0x0f);
│                              ^ ~~~~~~~~~~~~
│ 6 warnings generated.
│ ld: warning: option -s is obsolete and being ignored
│ Undefined symbols for architecture arm64:
│   "_png_init_filter_functions_neon", referenced from:
│       _png_read_filter_row in libpng.a(pngrutil.o)
│ ld: symbol(s) not found for architecture arm64
│ clang: error: linker command failed with exit code 1 (use -v to see invocation)
│ make[1]: *** [optipng] Error 1
│ make: *** [install] Error 2
```

But with the patch we get:

```
node_modules/.pnpm/optipng-bin@7.0.1/node_modules/optipng-bin: Running postinstall script, done in 5s
```

(I was using pnpm instead of npm)
